### PR TITLE
Make the git repo to clone from configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default["hub"]["install_path"] = "/usr/local"
 default["hub"]["src_path"] = "#{node.hub.install_path}/src"
+default["hub"]["git_repo"] = "https://github.com/github/hub.git"

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,3 +17,9 @@ attribute "git/src_path",
   description: "Path where hub git repo will be cloned",
   type: "string",
   required: "optional"
+
+attribute "hub/git_repo",
+  display_name: "Git repo",
+  description: "Git repo which will be cloned",
+  type: "string",
+  required: "optional"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,7 +13,7 @@ bash "install hub" do
   cwd node.hub.src_path
   code <<-BASH
   if [[ ! -d hub ]]; then
-    git clone https://github.com/defunkt/hub.git
+    git clone #{node.hub.git_repo}
     cd hub
   else
     cd hub


### PR DESCRIPTION
I updated the git repo URL from the old repo (https://github.com/defunkt/hub.git) to the new repo (https://github.com/github/hub.git) and I also made it configurable, because I wanted to have the ability to install hub from a personal fork that has some fixes to make it work with GitHub Enterprise.
