### PR TITLE
Using script/build since Rakefile no longer exists

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default["hub"]["install_path"] = "/usr/local"
 default["hub"]["src_path"] = "#{node.hub.install_path}/src"
+default["hub"]["repo"] = "https://github.com/github/hub.git"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,13 +13,14 @@ bash "install hub" do
   cwd node.hub.src_path
   code <<-BASH
   if [[ ! -d hub ]]; then
-    git clone https://github.com/defunkt/hub.git
+    git clone #{node.hub.repo}
     cd hub
   else
     cd hub
     git pull origin master
   fi
-  rake install prefix=#{node.hub.install_path}
+  ./script/build
+  cp hub #{node.hub.install_path}
   BASH
   action :run
 end


### PR DESCRIPTION
# The Problem

The newest version of hub no longer has a Rakefile which makes calling `rake install prefix=path` error out.
# The Solution

Switched the call to `./script/build` and `cp hub "#{node.hub.install_path}"` which results in the intended behaviour.

While updating I noticed it was pointing to the old repo path, so I've updated it here. I've also moved the into an attribute since people might want to pull their own forks.
